### PR TITLE
Reinstates posts timeline test

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -38,6 +38,6 @@
   </div>
 
   <form class="add-post-btn" action="/posts/new" method="get">
-    <button type="submit"><i class="fas fa-feather-alt"></i></button>
+    <button id="add-post" type="submit"><i class="fas fa-feather-alt"></i></button>
   </form>
 </div>

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -8,4 +8,15 @@ RSpec.feature "Timeline", type: :feature do
     click_button "Submit"
     expect(page).to have_content("Hello, world!")
   end
+
+  scenario "Last post is on top" do
+    visit "/posts"
+    click_link "New post"
+    fill_in "Message", with: "Message 1"
+    click_button "Submit"
+    click_link "New post"
+    fill_in "Message", with: "Message 2"
+    click_button "Submit"
+    expect(page.find('p:nth-of-type(1)')).to have_content("Message 2")
+  end
 end

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature "Timeline", type: :feature do
   scenario "Can submit posts and view them" do
     visit "/posts"
-    click_link "New post"
+    click_button "add-post"
     fill_in "Message", with: "Hello, world!"
     click_button "Submit"
     expect(page).to have_content("Hello, world!")
@@ -11,10 +11,10 @@ RSpec.feature "Timeline", type: :feature do
 
   scenario "Last post is on top" do
     visit "/posts"
-    click_link "New post"
+    click_button "add-post"
     fill_in "Message", with: "Message 1"
     click_button "Submit"
-    click_link "New post"
+    click_button "add-post"
     fill_in "Message", with: "Message 2"
     click_button "Submit"
     expect(page.find('p:nth-of-type(1)')).to have_content("Message 2")


### PR DESCRIPTION
resolves #30 

note that the reinstated test currently fails, because the pages styling has moved on in the meantime.  new ticket required to update the test according to the new styling.